### PR TITLE
fix(injector): correct assign expression to argument 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-      - "0.12"
+      - 8

--- a/lib/injector.js
+++ b/lib/injector.js
@@ -8,7 +8,7 @@ var profiler = require('./profiler');
  * inject profile
  * @param fileName {String} target file name
  * @param source {String} target source code
- * @param interval {Number} interval to output a profile
+ * @param interval {Number} interval(seconds) to output a profile
  * @return {String} profile-injected source code
  */
 function inject(fileName, source, interval){
@@ -18,12 +18,12 @@ function inject(fileName, source, interval){
 
     estraverse.traverse(ast, {
         enter: function (node, parent) {
-            /* 
+            /*
              rewrite function
                  function foo(){ body } -> function() { start('foo'); body; end; }
                  function(){ body } -> function() { start('anonymous'); body; end; }
             */
-            if(node.type === "FunctionDeclaration" || 
+            if(node.type === "FunctionDeclaration" ||
                node.type === "FunctionExpression"){
 
                  var funcName = node.id === null ? 'anonymous' : node.id.name;
@@ -101,10 +101,11 @@ function wrapReturn(returnStmt){
     );
 
     // rewrite __here__
-    wrapperFunc.expression.callee.object.body.body[0].declarations[0].init = 
+    wrapperFunc.expression.callee.object.body.body[0].declarations[0].init =
     returnStmt.argument;
 
-    returnStmt.argument = wrapperFunc;
+    // assign express to argument.
+    returnStmt.argument = wrapperFunc.expression;
 }
 
 function rewriteFuncName(funcAst, funcName){

--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -53,10 +53,11 @@ var profilerCode = [
 
 function profiler(interval){
     // rewrite interval number
-    var last = profilerCode.length-1;
-    profilerCode[last] = profilerCode[last].replace(/INTERVAL/, interval);
+    var copiedProfileCode = profilerCode.slice();
+    var last = copiedProfileCode.length-1;
+    copiedProfileCode[last] = copiedProfileCode[last].replace(/INTERVAL/, String(interval));
 
-    return esprima.parse(profilerCode.join('')).body;
+    return esprima.parse(copiedProfileCode.join('')).body;
 }
 
 module.exports = profiler;

--- a/package.json
+++ b/package.json
@@ -7,18 +7,19 @@
     "type": "git",
     "url": "git://github.com/45deg/node-sjsp.git"
   },
+  "main": "lib/injector.js",
   "bin": {
     "sjsp": "index.js"
   },
   "dependencies": {
     "commander": "^2.8.1",
     "escodegen": "^1.6.1",
-    "esprima": "^2.4.1",
+    "esprima": "^4.0.0",
     "estraverse": "^4.1.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",
-    "mocha": "^2.2.5"
+    "mocha": "^4.0.1"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/main.js"

--- a/test/fixtures/if-block-return/input.js
+++ b/test/fixtures/if-block-return/input.js
@@ -1,0 +1,5 @@
+function fn() {
+    if (true) {
+        return 1;
+    }
+}

--- a/test/fixtures/if-block-return/output.js
+++ b/test/fixtures/if-block-return/output.js
@@ -1,0 +1,11 @@
+function fn() {
+    var sjsp__state = sjsp__start('example.js', 1, 15, 'fn', 'function fn() {');
+    if (true) {
+        return function (arguments) {
+            var sjsp__return = 1;
+            sjsp__end(sjsp__state);
+            return sjsp__return;
+        }.call(this, arguments);
+    }
+    sjsp__end(sjsp__state);
+}

--- a/test/fixtures/if-else-no-block-return/input.js
+++ b/test/fixtures/if-else-no-block-return/input.js
@@ -1,0 +1,6 @@
+function fn() {
+    if (true)
+       return 1;
+    else
+       return 2;
+}

--- a/test/fixtures/if-else-no-block-return/output.js
+++ b/test/fixtures/if-else-no-block-return/output.js
@@ -1,0 +1,16 @@
+function fn() {
+    var sjsp__state = sjsp__start('example.js', 1, 15, 'fn', 'function fn() {');
+    if (true)
+        return function (arguments) {
+            var sjsp__return = 1;
+            sjsp__end(sjsp__state);
+            return sjsp__return;
+        }.call(this, arguments);
+    else
+        return function (arguments) {
+            var sjsp__return = 2;
+            sjsp__end(sjsp__state);
+            return sjsp__return;
+        }.call(this, arguments);
+    sjsp__end(sjsp__state);
+}

--- a/test/fixtures/if-no-block-return/input.js
+++ b/test/fixtures/if-no-block-return/input.js
@@ -1,0 +1,4 @@
+function fn() {
+    if (true)
+       return 1;
+}

--- a/test/fixtures/if-no-block-return/output.js
+++ b/test/fixtures/if-no-block-return/output.js
@@ -1,0 +1,10 @@
+function fn() {
+    var sjsp__state = sjsp__start('example.js', 1, 15, 'fn', 'function fn() {');
+    if (true)
+        return function (arguments) {
+            var sjsp__return = 1;
+            sjsp__end(sjsp__state);
+            return sjsp__return;
+        }.call(this, arguments);
+    sjsp__end(sjsp__state);
+}

--- a/test/main.js
+++ b/test/main.js
@@ -4,6 +4,29 @@ var estraverse = require('estraverse');
 var escodegen = require('escodegen');
 var profiler = require('../lib/profiler');
 var injector = require('../lib/injector');
+var fs = require("fs");
+var path = require("path");
+
+describe("fixture tests", function() {
+    const fixturesDir = path.join(__dirname, "fixtures");
+    const TEST_INTERVAL = 1;
+    const profileBody = profiler(TEST_INTERVAL);
+    const profileCode = escodegen.generate({
+        type: "Program",
+        body: profileBody
+    });
+    const dummyFileName = "example.js";
+    fs.readdirSync(fixturesDir).map(caseName => {
+        it(`should inject profiler for ${caseName.replace(/-/g, " ")}`, () => {
+            const fixtureDir = path.join(fixturesDir, caseName);
+            const actualPath = path.join(fixtureDir, "input.js");
+            const actual = injector.inject(dummyFileName, fs.readFileSync(actualPath, "utf-8"), TEST_INTERVAL);
+            const expected = fs.readFileSync(path.join(fixtureDir, "output.js"), "utf-8");
+            const profileWithExpected = profileCode + "\n"+ expected;
+            assert.deepStrictEqual(actual.trim(), profileWithExpected.trim(), actual);
+        });
+    });
+});
 
 describe("lib/profiler", function(){
     it("setInterval argument should be SECONDS * 1000", function(){


### PR DESCRIPTION
This PR fixes to support following pattern:

```js
function fn(){ 
  if(condition) return statement;
  else return statement;
}
```

Previously, the conveted result is syntax error.